### PR TITLE
Lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # m4 cache
 *.cache
 
+# hdt
+*.hdt.index
+*.hdt.index.v1-1
+
 # C++ Configure and Make
 Makefile
 Makefile.in

--- a/README.md
+++ b/README.md
@@ -38,25 +38,29 @@ Usage
 For reading a HDT file you must use `HDTConnector` object from which you can do a search. Each search will return an iterator with the matching triples. For example:
 
 ```python
+from itertools import islice
 from hdtconnector.libhdtconnector import HDTConnector
 m_map = HDTConnector("my/path.hdt")
 
-# All the collection
+# Read the 10-first elements in the collection
 iter = m_map.search("", "", "")
-while iter.has_next():
-  print( iter.next().get_subject() )
+for triple in islice(iter, 10):
+  print( triple.get_subject() )
 
 # Specific subset
-resource = "some interesting resource"
+resource = "some/interesting/resource"
 iter = m_map.search(resource, "", "")
-while iter.has_next():
-  elem = iter.next()
-  print( elem.get_subject() )
-  print( elem.get_object() )
-  print( elem.get_predicate() )
+for triple in iter:
+  print( triple.get_subject() )
+  print( triple.get_object() )
+  print( triple.get_predicate() )
+
+# Search by Ids
+from hdtconnector.libhdtconnector import triple_role
+
+id = m_map.uri_to_id( resource, triple_role.subject)
+iter = m_map.search_id( id, 0, 0) # 0 means *
+for triple in iter:
+  print( triple.get_object() )
 
 ```
-
-
-
-

--- a/hdtconnector/tests/test_libhdtconnector.py
+++ b/hdtconnector/tests/test_libhdtconnector.py
@@ -1,34 +1,43 @@
 import unittest
+from itertools import islice
 from hdtconnector.libhdtconnector import HDTConnector
 from hdtconnector.libhdtconnector import triple_role
 
 m_file = "etc/test.hdt"
 
 class TestHDTConnector(unittest.TestCase):
-  def test_basic_hdt(self):
+  def test_should_iterate_hdt_file_getting_uris(self):
     m_map = HDTConnector(m_file)
-    iter = m_map.search("", "", "")
-    while iter.has_next():
-      print( iter.next().get_subject() )
+    t_list = list(islice(m_map.search("", "", ""), 10))
+    self.assertEqual(len(t_list), 10)
+
+  def test_should_obtain_str_from_a_uri_iterator(self):
+    m_map = HDTConnector(m_file)
+    triple = next(m_map.search("", "", ""))
+    self.assertIsInstance(triple.get_subject(), str)
+    self.assertIsInstance(triple.get_predicate(), str)
+    self.assertIsInstance(triple.get_object(), str)
 
   def test_should_iterate_hdt_file_getting_ids(self):
     m_map = HDTConnector(m_file)
-    iter = m_map.search_id("", "", "")
-    while iter.has_next():
-      print( iter.next().get_subject() )
+    t_list = list(islice(m_map.search_id("", "", ""), 10))
+    self.assertEqual(len(t_list), 10)
 
   def test_should_iterate_hdt_file_by_using_ids_in_search(self):
     m_map = HDTConnector(m_file)
-    iter = m_map.search_id("", "", "")
-    triple = iter.next()
-    iter = m_map.search_id(triple.get_subject(), triple.get_predicate(), triple.get_object())
-    while iter.has_next():
-      print( iter.next().get_subject() )
+    triple = next(m_map.search_id("", "", ""))
+    t_list = list(islice(m_map.search_id(triple.get_subject(), 0, 0), 10))
+    self.assertEqual(len(t_list), 10)
+
+  def test_should_iterate_search_until_get_a_stop_exception(self):
+    m_map = HDTConnector(m_file)
+    with self.assertRaises(StopIteration):
+       iter = m_map.search("some/non/existing/resource", "", "")
+       iter.__next__()
 
   def test_should_transform_id_into_url(self):
     m_map = HDTConnector(m_file)
-    iter = m_map.search_id("", "", "")
-    triple = iter.next()
+    triple = next(m_map.search_id("", "", ""))
     s_uri = m_map.id_to_uri( triple.get_subject(), triple_role.subject)
     p_uri = m_map.id_to_uri( triple.get_predicate(), triple_role.predicate)
     o_uri = m_map.id_to_uri( triple.get_object(), triple_role.object)
@@ -41,8 +50,7 @@ class TestHDTConnector(unittest.TestCase):
 
   def test_should_transform_uri_into_id(self):
     m_map = HDTConnector(m_file)
-    iter = m_map.search("", "", "")
-    triple = iter.next()
+    triple = next(m_map.search("", "", ""))
     s_id = m_map.uri_to_id( triple.get_subject(), triple_role.subject)
     p_id = m_map.uri_to_id( triple.get_predicate(), triple_role.predicate)
     o_id = m_map.uri_to_id( triple.get_object(), triple_role.object)

--- a/hdtconnector/tests/test_libhdtconnector.py
+++ b/hdtconnector/tests/test_libhdtconnector.py
@@ -1,5 +1,6 @@
 import unittest
 from hdtconnector.libhdtconnector import HDTConnector
+from hdtconnector.libhdtconnector import triple_role
 
 m_file = "etc/test.hdt"
 
@@ -15,6 +16,34 @@ class TestHDTConnector(unittest.TestCase):
     iter = m_map.search_id("", "", "")
     while iter.has_next():
       print( iter.next().get_subject() )
+
+  def test_should_transform_id_into_url(self):
+    m_map = HDTConnector(m_file)
+    iter = m_map.search_id("", "", "")
+    triple = iter.next()
+    s_uri = m_map.id_to_uri( triple.get_subject(), triple_role.subject)
+    p_uri = m_map.id_to_uri( triple.get_predicate(), triple_role.predicate)
+    o_uri = m_map.id_to_uri( triple.get_object(), triple_role.object)
+    s_id = m_map.uri_to_id( s_uri, triple_role.subject)
+    p_id = m_map.uri_to_id( p_uri, triple_role.predicate)
+    o_id = m_map.uri_to_id( o_uri, triple_role.object)
+    self.assertEqual(triple.get_subject(), s_id)
+    self.assertEqual(triple.get_predicate(), p_id)
+    self.assertEqual(triple.get_object(), o_id)
+
+  def test_should_transform_uri_into_id(self):
+    m_map = HDTConnector(m_file)
+    iter = m_map.search("", "", "")
+    triple = iter.next()
+    s_id = m_map.uri_to_id( triple.get_subject(), triple_role.subject)
+    p_id = m_map.uri_to_id( triple.get_predicate(), triple_role.predicate)
+    o_id = m_map.uri_to_id( triple.get_object(), triple_role.object)
+    s_uri = m_map.id_to_uri( s_id, triple_role.subject)
+    p_uri = m_map.id_to_uri( p_id, triple_role.predicate)
+    o_uri = m_map.id_to_uri( o_id, triple_role.object)
+    self.assertEqual(triple.get_subject(), s_uri)
+    self.assertEqual(triple.get_predicate(), p_uri)
+    self.assertEqual(triple.get_object(), o_uri)
 
   def test_should_create_c_object_and_delete_when_not_used(self):
     m_map = HDTConnector(m_file)

--- a/hdtconnector/tests/test_libhdtconnector.py
+++ b/hdtconnector/tests/test_libhdtconnector.py
@@ -17,6 +17,14 @@ class TestHDTConnector(unittest.TestCase):
     while iter.has_next():
       print( iter.next().get_subject() )
 
+  def test_should_iterate_hdt_file_by_using_ids_in_search(self):
+    m_map = HDTConnector(m_file)
+    iter = m_map.search_id("", "", "")
+    triple = iter.next()
+    iter = m_map.search_id(triple.get_subject(), triple.get_predicate(), triple.get_object())
+    while iter.has_next():
+      print( iter.next().get_subject() )
+
   def test_should_transform_id_into_url(self):
     m_map = HDTConnector(m_file)
     iter = m_map.search_id("", "", "")

--- a/hdtconnector/tests/test_libhdtconnector.py
+++ b/hdtconnector/tests/test_libhdtconnector.py
@@ -32,8 +32,17 @@ class TestHDTConnector(unittest.TestCase):
   def test_should_iterate_search_until_get_a_stop_exception(self):
     m_map = HDTConnector(m_file)
     with self.assertRaises(StopIteration):
-       iter = m_map.search("some/non/existing/resource", "", "")
-       iter.__next__()
+      next( m_map.search("some/non/existing/resource", "", ""))
+
+  def test_should_iterate_search_id_with_ids_until_get_a_stop_exception(self):
+    m_map = HDTConnector(m_file)
+    with self.assertRaises(StopIteration):
+      next( m_map.search_id(123123123, 0, 0) )
+
+  def test_should_iterate_search_id_with_uris_until_get_a_stop_exception(self):
+    m_map = HDTConnector(m_file)
+    with self.assertRaises(StopIteration):
+      next( m_map.search_id("some/non/existing/resource", "", ""))
 
   def test_should_transform_id_into_url(self):
     m_map = HDTConnector(m_file)

--- a/hdtconnector/tests/test_libhdtconnector.py
+++ b/hdtconnector/tests/test_libhdtconnector.py
@@ -10,6 +10,12 @@ class TestHDTConnector(unittest.TestCase):
     while iter.has_next():
       print( iter.next().get_subject() )
 
+  def test_should_iterate_hdt_file_getting_ids(self):
+    m_map = HDTConnector(m_file)
+    iter = m_map.search_id("", "", "")
+    while iter.has_next():
+      print( iter.next().get_subject() )
+
   def test_should_create_c_object_and_delete_when_not_used(self):
     m_map = HDTConnector(m_file)
     del m_map

--- a/libhdtconnector/configure.ac
+++ b/libhdtconnector/configure.ac
@@ -4,10 +4,11 @@ AC_INIT([hdtconnector], [1.0], [pablo.torres.t@gmail.com])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build])
-AC_CONFIG_HEADERS([build/config.h])
+AC_CONFIG_HEADERS([src/config.h])
 m4_include([m4-additional/ax_python_embed.m4])
 m4_include([m4-additional/ax_python_devel.m4])
 m4_include([m4-additional/ax_boost_base.m4])
+m4_include([m4-additional/ax_boost_locale.m4])
 m4_include([m4-additional/ax_boost_python.m4])
 m4_include([m4-additional/ax_require_defined.m4])
 m4_include([m4-additional/ax_cxx_compile_stdcxx.m4])
@@ -31,15 +32,17 @@ PKG_CHECK_MODULES([HDT], [hdt],[
 AC_CHECK_HEADERS([HDT.hpp], [], 
   AC_MSG_ERROR([Could not find HDT.hpp]))
 
-# Find Python
-#AX_PYTHON_DEVEL([ >= '3.2'])
-
-# Find boost 
-#AX_BOOST_BASE([1.57], [], 
-#  AC_MSG_ERROR([Could not find Boost Library]))
-
 # Find boost-python
 AX_BOOST_PYTHON
+
+# Find a recent glib version. If not, then use boost locale
+PKG_CHECK_MODULES([GLIB],[glib-2.0 >= 2.20],
+  [AC_DEFINE([HAVE_GLIB_2_2X], [1], [Have GLIB 2X])]
+  [enable_boost_locale=no],
+  [AX_BOOST_LOCALE]
+  [enable_boost_locale=yes]
+  )
+AM_CONDITIONAL([WANTS_BOOST_LOCALE],[ test "x$enable_boost_locale != xno"])
 
 AC_CONFIG_FILES([
   Makefile

--- a/libhdtconnector/configure.ac
+++ b/libhdtconnector/configure.ac
@@ -36,8 +36,8 @@ AC_CHECK_HEADERS([HDT.hpp], [],
 AX_BOOST_PYTHON
 
 # Find a recent glib version. If not, then use boost locale
-PKG_CHECK_MODULES([GLIB],[glib-2.0 >= 2.20],
-  [AC_DEFINE([HAVE_GLIB_2_2X], [1], [Have GLIB 2X])]
+AC_CHECK_HEADER([codecvt],
+  [AC_DEFINE([HAVE_CODECVT], [1], [Have GLIB 2X])]
   [enable_boost_locale=no],
   [AX_BOOST_LOCALE]
   [enable_boost_locale=yes]

--- a/libhdtconnector/m4-additional/ax_boost_locale.m4
+++ b/libhdtconnector/m4-additional/ax_boost_locale.m4
@@ -1,0 +1,119 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_locale.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_LOCALE
+#
+# DESCRIPTION
+#
+#   Test for System library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_LOCALE_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_LOCALE
+#
+# LICENSE
+#
+#   Copyright (c) 2012 Xiyue Deng <manphiz@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_BOOST_LOCALE],
+[
+	AC_ARG_WITH([boost-locale],
+	AS_HELP_STRING([--with-boost-locale@<:@=special-lib@:>@],
+                   [use the Locale library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-locale=boost_locale-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_locale_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_locale_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Locale library is available,
+					   ax_cv_boost_locale,
+        [AC_LANG_PUSH([C++])
+			 CXXFLAGS_SAVE=$CXXFLAGS
+
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/locale.hpp>]],
+                                   [[boost::locale::generator gen;
+                                   std::locale::global(gen(""));]])],
+                   ax_cv_boost_locale=yes, ax_cv_boost_locale=no)
+			 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_locale" = "xyes"; then
+			AC_SUBST(BOOST_CPPFLAGS)
+
+			AC_DEFINE(HAVE_BOOST_LOCALE,,[define if the Boost::Locale library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+			LDFLAGS_SAVE=$LDFLAGS
+            if test "x$ax_boost_user_locale_lib" = "x"; then
+                for libextension in `ls $BOOSTLIBDIR/libboost_locale*.so* $BOOSTLIBDIR/libboost_locale*.dylib* $BOOSTLIBDIR/libboost_locale*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_locale.*\)\.so.*$;\1;' -e 's;^lib\(boost_locale.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_locale.*\)\.a.*$;\1;'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_LOCALE_LIB="-l$ax_lib"; AC_SUBST(BOOST_LOCALE_LIB) link_locale="yes"; break],
+                                 [link_locale="no"])
+				done
+                if test "x$link_locale" != "xyes"; then
+                for libextension in `ls $BOOSTLIBDIR/boost_locale*.dll* $BOOSTLIBDIR/boost_locale*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_locale.*\)\.dll.*$;\1;' -e 's;^\(boost_locale.*\)\.a.*$;\1;'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_LOCALE_LIB="-l$ax_lib"; AC_SUBST(BOOST_LOCALE_LIB) link_locale="yes"; break],
+                                 [link_locale="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_locale_lib boost_locale-$ax_boost_user_locale_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_LOCALE_LIB="-l$ax_lib"; AC_SUBST(BOOST_LOCALE_LIB) link_locale="yes"; break],
+                                   [link_locale="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_locale" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/libhdtconnector/src/HDTConnector.cpp
+++ b/libhdtconnector/src/HDTConnector.cpp
@@ -48,15 +48,21 @@ HDTConnector::search_id(const wstring& uri1, const wstring& uri2, const wstring 
     // If couldn't found the uris, return an empty iterator
     return make_shared<HDTIteratorTripleID>( new IteratorTripleID() );
   }
-
-  return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
+  return search_id(tid);
 }
 
 shared_ptr<HDTIteratorTripleID>
 HDTConnector::search_id(unsigned int id1, unsigned int id2, unsigned int id3)
 {
   TripleID tid(id1, id2, id3);
-  return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
+  return search_id(tid);
+}
+
+shared_ptr<HDTIteratorTripleID>
+HDTConnector::search_id(TripleID& triple)
+{
+  // search should receive a const tripleID&
+  return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(triple) );
 }
 
 wstring

--- a/libhdtconnector/src/HDTConnector.cpp
+++ b/libhdtconnector/src/HDTConnector.cpp
@@ -51,6 +51,13 @@ HDTConnector::search_id(const wstring& uri1, const wstring& uri2, const wstring 
   return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
 }
 
+shared_ptr<HDTIteratorTripleID>
+HDTConnector::search_id(unsigned int id1, unsigned int id2, unsigned int id3)
+{
+  TripleID tid(id1, id2, id3);
+  return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
+}
+
 string
 HDTConnector::id_to_uri(unsigned int id, TripleComponentRole role)
 {

--- a/libhdtconnector/src/HDTConnector.cpp
+++ b/libhdtconnector/src/HDTConnector.cpp
@@ -45,7 +45,8 @@ HDTConnector::search_id(const wstring& uri1, const wstring& uri2, const wstring 
        ( tid.getPredicate() == 0 && !suri2.empty() ) ||
        ( tid.getObject() == 0 && !suri3.empty() ) )
   {
-    return nullptr;
+    // If couldn't found the uris, return an empty iterator
+    return make_shared<HDTIteratorTripleID>( new IteratorTripleID() );
   }
 
   return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );

--- a/libhdtconnector/src/HDTConnector.cpp
+++ b/libhdtconnector/src/HDTConnector.cpp
@@ -34,9 +34,9 @@ HDTConnector::search(const wstring& w_uri1, const wstring& w_uri2, const wstring
 shared_ptr<HDTIteratorTripleID>
 HDTConnector::search_id(const wstring& uri1, const wstring& uri2, const wstring &uri3)
 {
-  const string suri1( uri1.begin(), uri1.end() );
-  const string suri2( uri2.begin(), uri2.end() );
-  const string suri3( uri3.begin(), uri3.end() );
+  const string suri1 = Utilities::unicode_to_utf8(uri1);
+  const string suri2 = Utilities::unicode_to_utf8(uri2);
+  const string suri3 = Utilities::unicode_to_utf8(uri3);
   TripleString ts(suri1, suri2, suri3);
   TripleID tid;
   hdt -> getDictionary() -> tripleStringtoTripleID(ts, tid);
@@ -58,14 +58,15 @@ HDTConnector::search_id(unsigned int id1, unsigned int id2, unsigned int id3)
   return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
 }
 
-string
-HDTConnector::id_to_uri(unsigned int id, TripleComponentRole role)
+wstring
+HDTConnector::id_to_uri(unsigned int id, const TripleComponentRole& role)
 {
-  return hdt -> getDictionary() -> idToString(id, role);
+  return Utilities::utf8_to_unicode(hdt -> getDictionary() -> idToString(id, role));
 }
 
 unsigned int
-HDTConnector::uri_to_id(string uri, TripleComponentRole role)
+HDTConnector::uri_to_id(const wstring& uri, const TripleComponentRole& role)
 {
-  return hdt -> getDictionary() -> stringToId(uri, role);
+  return hdt -> getDictionary() -> stringToId(
+      Utilities::unicode_to_utf8(uri), role);
 }

--- a/libhdtconnector/src/HDTConnector.cpp
+++ b/libhdtconnector/src/HDTConnector.cpp
@@ -31,3 +31,22 @@ HDTConnector::search(const wstring& w_uri1, const wstring& w_uri2, const wstring
 	return make_shared<HDTIterator>(iter);
 }
 
+shared_ptr<HDTIteratorTripleID>
+HDTConnector::search_id(const wstring& uri1, const wstring& uri2, const wstring &uri3)
+{
+  const string suri1( uri1.begin(), uri1.end() );
+  const string suri2( uri2.begin(), uri2.end() );
+  const string suri3( uri3.begin(), uri3.end() );
+  TripleString ts(suri1, suri2, suri3);
+  TripleID tid;
+  hdt -> getDictionary() -> tripleStringtoTripleID(ts, tid);
+  // Check if ids were found in hdtfile.
+  if ( ( tid.getSubject() == 0 && !suri1.empty() ) ||
+       ( tid.getPredicate() == 0 && !suri2.empty() ) ||
+       ( tid.getObject() == 0 ) && !suri3.empty() )
+  {
+    return nullptr;
+  }
+
+  return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
+}

--- a/libhdtconnector/src/HDTConnector.cpp
+++ b/libhdtconnector/src/HDTConnector.cpp
@@ -43,10 +43,22 @@ HDTConnector::search_id(const wstring& uri1, const wstring& uri2, const wstring 
   // Check if ids were found in hdtfile.
   if ( ( tid.getSubject() == 0 && !suri1.empty() ) ||
        ( tid.getPredicate() == 0 && !suri2.empty() ) ||
-       ( tid.getObject() == 0 ) && !suri3.empty() )
+       ( tid.getObject() == 0 && !suri3.empty() ) )
   {
     return nullptr;
   }
 
   return make_shared<HDTIteratorTripleID>( hdt -> getTriples() -> search(tid) );
+}
+
+string
+HDTConnector::id_to_uri(unsigned int id, TripleComponentRole role)
+{
+  return hdt -> getDictionary() -> idToString(id, role);
+}
+
+unsigned int
+HDTConnector::uri_to_id(string uri, TripleComponentRole role)
+{
+  return hdt -> getDictionary() -> stringToId(uri, role);
 }

--- a/libhdtconnector/src/HDTIterator.cpp
+++ b/libhdtconnector/src/HDTIterator.cpp
@@ -1,4 +1,4 @@
-#include <HDTIterator.h>
+#include "HDTIterator.h"
 
 HDTIterator::HDTIterator(IteratorTripleString *iter) : iter(iter)
 {
@@ -13,17 +13,6 @@ HDTIterator::~HDTIterator()
 	}
 }
 
-bool
-HDTIterator::has_next()
-{
-	if ( !iter )
-	{
-		cout << "iter is null" << endl;
-		return false;
-	}
-	return iter -> hasNext();
-}
-
 shared_ptr<HDTTriple>
 HDTIterator::next()
 {
@@ -31,5 +20,7 @@ HDTIterator::next()
 	{
 		return make_shared<HDTTriple>( iter -> next());
 	}
+  PyErr_SetString(PyExc_StopIteration, "No more data");
+  throw_error_already_set();
 	return nullptr;
 }

--- a/libhdtconnector/src/HDTIteratorTripleID.cpp
+++ b/libhdtconnector/src/HDTIteratorTripleID.cpp
@@ -1,0 +1,34 @@
+#include "HDTIteratorTripleID.h"
+
+HDTIteratorTripleID::HDTIteratorTripleID(IteratorTripleID *iter) : iter(iter)
+{
+}
+
+HDTIteratorTripleID::~HDTIteratorTripleID()
+{
+  if ( iter )
+  {
+    delete iter;
+    iter = NULL;
+  }
+}
+
+bool
+HDTIteratorTripleID::has_next() const
+{
+  if ( !iter )
+  {
+    return false;
+  }
+  return iter -> hasNext();
+}
+
+shared_ptr<HDTTripleID>
+HDTIteratorTripleID::next()
+{
+  if ( iter -> hasNext() )
+  {
+    return make_shared<HDTTripleID>( iter -> next() );
+  }
+  return nullptr;
+}

--- a/libhdtconnector/src/HDTIteratorTripleID.cpp
+++ b/libhdtconnector/src/HDTIteratorTripleID.cpp
@@ -13,16 +13,6 @@ HDTIteratorTripleID::~HDTIteratorTripleID()
   }
 }
 
-bool
-HDTIteratorTripleID::has_next() const
-{
-  if ( !iter )
-  {
-    return false;
-  }
-  return iter -> hasNext();
-}
-
 shared_ptr<HDTTripleID>
 HDTIteratorTripleID::next()
 {
@@ -30,5 +20,7 @@ HDTIteratorTripleID::next()
   {
     return make_shared<HDTTripleID>( iter -> next() );
   }
+  PyErr_SetString(PyExc_StopIteration, "No more data");
+  throw_error_already_set();
   return nullptr;
 }

--- a/libhdtconnector/src/HDTTriple.cpp
+++ b/libhdtconnector/src/HDTTriple.cpp
@@ -1,31 +1,40 @@
 #include "HDTTriple.h"
 
-HDTTriple::HDTTriple(TripleString *triple) : triple(triple)
+HDTTriple::HDTTriple(TripleString *triple)
 {
+  // The triple provided by the interator is local
+  // to the Iterator class, thus if next is call the object
+  // is changed. To avoid inconsistency with pre-fetching, we
+  // copy the value into a local variable that is deleted only
+  // when the this object is not used anymore.
+  this -> triple = new TripleString( triple -> getSubject(), 
+                             triple -> getPredicate(),
+                             triple -> getObject() );
 }
 
 HDTTriple::~HDTTriple()
 {
   if ( triple )
   {
+    delete triple;
     triple = NULL;
   }
 }
 
-string
+wstring
 HDTTriple::get_subject() const
 {
-  return triple -> getSubject();
+  return Utilities::utf8_to_unicode( triple -> getSubject() );
 }
 
-string
+wstring
 HDTTriple::get_object() const
 {
-  return triple -> getObject();
+  return Utilities::utf8_to_unicode( triple -> getObject() );
 }
 
-string
+wstring
 HDTTriple::get_predicate() const
 {
-  return triple -> getPredicate();
+  return Utilities::utf8_to_unicode( triple -> getPredicate() );
 }

--- a/libhdtconnector/src/HDTTripleID.cpp
+++ b/libhdtconnector/src/HDTTripleID.cpp
@@ -1,0 +1,33 @@
+#include "HDTTripleID.h"
+
+HDTTripleID::HDTTripleID(TripleID *triple) : triple(triple)
+{
+}
+
+HDTTripleID::~HDTTripleID()
+{
+  if ( triple )
+  {
+    // Note that triple is a reference, hence it 
+    // cannot be deleted
+    triple = NULL;
+  }
+}
+
+unsigned int
+HDTTripleID::get_subject() const
+{
+  return triple -> getSubject();
+}
+
+unsigned int
+HDTTripleID::get_predicate() const
+{
+  return triple -> getPredicate();
+}
+
+unsigned int
+HDTTripleID::get_object() const
+{
+  return triple -> getObject();
+}

--- a/libhdtconnector/src/HDTTripleID.cpp
+++ b/libhdtconnector/src/HDTTripleID.cpp
@@ -1,15 +1,22 @@
 #include "HDTTripleID.h"
 
-HDTTripleID::HDTTripleID(TripleID *triple) : triple(triple)
+HDTTripleID::HDTTripleID(TripleID *triple)
 {
+  // The triple provided by the interator is local
+  // to the Iterator class, thus if next is call the object
+  // is changed. To avoid inconsistency with pre-fetching, we
+  // copy the value into a local variable that is deleted only
+  // when the this object is not used anymore.
+  this -> triple = new TripleID(triple -> getSubject(),
+                        triple -> getPredicate(),
+                        triple -> getObject());
 }
 
 HDTTripleID::~HDTTripleID()
 {
   if ( triple )
   {
-    // Note that triple is a reference, hence it 
-    // cannot be deleted
+    delete triple;
     triple = NULL;
   }
 }

--- a/libhdtconnector/src/Makefile.am
+++ b/libhdtconnector/src/Makefile.am
@@ -12,6 +12,7 @@ libhdtconnector_la_SOURCES = \
 	ConvertProgress.cpp \
 	HDTIterator.cpp \
 	HDTIteratorTripleID.cpp \
+	Utilities.cpp \
 	hdtconnector_so.cpp
 
 libhdtconnector_la_LIBADD = 

--- a/libhdtconnector/src/Makefile.am
+++ b/libhdtconnector/src/Makefile.am
@@ -7,9 +7,11 @@ libhdtconnector_la_CPPFLAGS = \
 
 libhdtconnector_la_SOURCES = \
 	HDTTriple.cpp \
+	HDTTripleID.cpp \
 	HDTConnector.cpp \
 	ConvertProgress.cpp \
 	HDTIterator.cpp \
+	HDTIteratorTripleID.cpp \
 	hdtconnector_so.cpp
 
 libhdtconnector_la_LIBADD = 

--- a/libhdtconnector/src/Makefile.am
+++ b/libhdtconnector/src/Makefile.am
@@ -2,8 +2,9 @@
 lib_LTLIBRARIES = libhdtconnector.la
 libhdtconnector_la_CPPFLAGS = \
 	-I./include \
-        $(BOOST_CPPFLAGS) \
-        $(PYTHON_CPPFLAGS) 
+	$(HDT_CPPFLAGS) \
+  $(BOOST_CPPFLAGS) \
+  $(PYTHON_CPPFLAGS) 
 
 libhdtconnector_la_SOURCES = \
 	HDTTriple.cpp \
@@ -20,7 +21,10 @@ libhdtconnector_la_LIBADD =
 libhdtconnector_la_LIBTOOLFLAGS = 
 
 libhdtconnector_la_LDFLAGS = \
-	-lhdt \
-        $(BOOST_LDFLAGS) -l$(BOOST_PYTHON_LIB) \
-        $(PYTHON_LIBS) \
-	$(PYTHON_EXTRA_LDFLAGS) 
+	$(HDT_LIBS) \
+  $(BOOST_LDFLAGS) -l$(BOOST_PYTHON_LIB) \
+  $(PYTHON_LIBS) $(PYTHON_EXTRA_LDFLAGS)
+
+if WANTS_BOOST_LOCALE
+libhdtconnector_la_LDFLAGS += $(BOOST_LOCALE_LIB)
+endif

--- a/libhdtconnector/src/Utilities.cpp
+++ b/libhdtconnector/src/Utilities.cpp
@@ -4,16 +4,17 @@
 
 #include "Utilities.h"
 
-#ifdef HAVE_GLIB_2_2X
+#ifdef HAVE_CODECVT
 wstring_convert<codecvt_utf8_utf16<wchar_t>> Utilities::converter;
 #endif
 
 string
 Utilities::unicode_to_utf8(const wstring& unicode)
 {
-#ifdef HAVE_GLIB_2_2X
+#ifdef HAV_CODECVT
   return converter.to_bytes(unicode);
-#elif HAVE_BOOST_LOCALE
+#endif
+#ifdef HAVE_BOOST_LOCALE
   return utf_to_utf<char>(unicode.c_str(), unicode.c_str() + unicode.size());
 #endif
 }
@@ -21,9 +22,10 @@ Utilities::unicode_to_utf8(const wstring& unicode)
 wstring
 Utilities::utf8_to_unicode(const string& utf8)
 {
-#ifdef HAVE_GLIB_2_2X
+#ifdef HAVE_CODECVT
   return converter.from_bytes(utf8);
-#elif HAVE_BOOST_LOCALE
-  return utf_to_utf<wchar>(unicode.c_str(), unicode.s_str() + unicode.size());
+#endif
+#ifdef HAVE_BOOST_LOCALE
+  return utf_to_utf<wchar_t>(utf8.c_str(), utf8.c_str() + utf8.size());
 #endif
 }

--- a/libhdtconnector/src/Utilities.cpp
+++ b/libhdtconnector/src/Utilities.cpp
@@ -1,0 +1,15 @@
+#include "Utilities.h"
+
+wstring_convert<codecvt_utf8_utf16<wchar_t>> Utilities::converter;
+
+string
+Utilities::unicode_to_utf8(const wstring& unicode)
+{
+  return converter.to_bytes(unicode);
+}
+
+wstring
+Utilities::utf8_to_unicode(const string& utf8)
+{
+  return converter.from_bytes(utf8);
+}

--- a/libhdtconnector/src/Utilities.cpp
+++ b/libhdtconnector/src/Utilities.cpp
@@ -11,7 +11,7 @@ wstring_convert<codecvt_utf8_utf16<wchar_t>> Utilities::converter;
 string
 Utilities::unicode_to_utf8(const wstring& unicode)
 {
-#ifdef HAV_CODECVT
+#ifdef HAVE_CODECVT
   return converter.to_bytes(unicode);
 #endif
 #ifdef HAVE_BOOST_LOCALE

--- a/libhdtconnector/src/Utilities.cpp
+++ b/libhdtconnector/src/Utilities.cpp
@@ -1,15 +1,29 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "Utilities.h"
 
+#ifdef HAVE_GLIB_2_2X
 wstring_convert<codecvt_utf8_utf16<wchar_t>> Utilities::converter;
+#endif
 
 string
 Utilities::unicode_to_utf8(const wstring& unicode)
 {
+#ifdef HAVE_GLIB_2_2X
   return converter.to_bytes(unicode);
+#elif HAVE_BOOST_LOCALE
+  return utf_to_utf<char>(unicode.c_str(), unicode.c_str() + unicode.size());
+#endif
 }
 
 wstring
 Utilities::utf8_to_unicode(const string& utf8)
 {
+#ifdef HAVE_GLIB_2_2X
   return converter.from_bytes(utf8);
+#elif HAVE_BOOST_LOCALE
+  return utf_to_utf<wchar>(unicode.c_str(), unicode.s_str() + unicode.size());
+#endif
 }

--- a/libhdtconnector/src/hdtconnector_so.cpp
+++ b/libhdtconnector/src/hdtconnector_so.cpp
@@ -14,6 +14,11 @@ static shared_ptr<HDTConnector> init_from_c_string(const string &val)
 	return make_shared<HDTConnector>(val);
 }
 
+// For functions with similar name, we need to wrap them in a pointer
+// and give that pointer to python
+shared_ptr<HDTIteratorTripleID> (HDTConnector::*search_id_1)(const wstring& uri1, const wstring& uri2, const wstring& uri3) = &HDTConnector::search_id;
+shared_ptr<HDTIteratorTripleID> (HDTConnector::*search_id_2)(unsigned int id1, unsigned int id2, unsigned int id3) = &HDTConnector::search_id;
+
 BOOST_PYTHON_MODULE(libhdtconnector)
 {
   enum_<TripleComponentRole>("triple_role")
@@ -45,7 +50,8 @@ BOOST_PYTHON_MODULE(libhdtconnector)
 	class_<HDTConnector, shared_ptr<HDTConnector> >("HDTConnector", no_init)
 		.def("__init__", make_constructor(&init_from_c_string))
 		.def("search", &HDTConnector::search)
-    .def("search_id", &HDTConnector::search_id)
+    .def("search_id", search_id_1) //Note that this is a pointer to a function
+    .def("search_id", search_id_2) //Note that this is a pointer to a function
     .def("id_to_uri", &HDTConnector::id_to_uri)
     .def("uri_to_id", &HDTConnector::uri_to_id)
 	  ;

--- a/libhdtconnector/src/hdtconnector_so.cpp
+++ b/libhdtconnector/src/hdtconnector_so.cpp
@@ -2,7 +2,9 @@
 #include <memory>
 #include "HDTConnector.h"
 #include "HDTIterator.h"
+#include "HDTIteratorTripleID.h"
 #include "HDTTriple.h"
+#include "HDTTripleID.h"
 
 using namespace std;
 using namespace boost::python;
@@ -19,16 +21,24 @@ BOOST_PYTHON_MODULE(libhdtconnector)
     .def("get_predicate", &HDTTriple::get_predicate )
     .def("get_object", &HDTTriple::get_object )
   ;
-  //register_ptr_to_python< shared_ptr<HDTTriple> >();
+  class_<HDTTripleID, shared_ptr<HDTTripleID> >("HDTTripleID", no_init)
+    .def("get_subject", &HDTTripleID::get_subject )
+    .def("get_predicate", &HDTTripleID::get_predicate )
+    .def("get_object", &HDTTripleID::get_object )
+  ;
 
 	class_<HDTIterator, shared_ptr<HDTIterator> >("HDTIterator", no_init)
 		.def("has_next", &HDTIterator::has_next)
 		.def("next", &HDTIterator::next)
 	;
-	//register_ptr_to_python< shared_ptr<HDTIterator> >();
-	
+  class_<HDTIteratorTripleID, shared_ptr<HDTIteratorTripleID> >("HDTIteratorTripleID", no_init)
+    .def("has_next", &HDTIteratorTripleID::has_next)
+    .def("next", &HDTIteratorTripleID::next)
+	;
+
 	class_<HDTConnector, shared_ptr<HDTConnector> >("HDTConnector", no_init)
 		.def("__init__", make_constructor(&init_from_c_string))
 		.def("search", &HDTConnector::search)
+    .def("search_id", &HDTConnector::search_id)
 	;
 }

--- a/libhdtconnector/src/hdtconnector_so.cpp
+++ b/libhdtconnector/src/hdtconnector_so.cpp
@@ -19,6 +19,10 @@ static shared_ptr<HDTConnector> init_from_c_string(const string &val)
 shared_ptr<HDTIteratorTripleID> (HDTConnector::*search_id_1)(const wstring& uri1, const wstring& uri2, const wstring& uri3) = &HDTConnector::search_id;
 shared_ptr<HDTIteratorTripleID> (HDTConnector::*search_id_2)(unsigned int id1, unsigned int id2, unsigned int id3) = &HDTConnector::search_id;
 
+// For our iterators, __iter__ method needs to pass the same object
+// so, it basically does nothing.
+inline object pass_through(object const& o) { return o; }
+
 BOOST_PYTHON_MODULE(libhdtconnector)
 {
   enum_<TripleComponentRole>("triple_role")
@@ -39,12 +43,12 @@ BOOST_PYTHON_MODULE(libhdtconnector)
     ;
 
 	class_<HDTIterator, shared_ptr<HDTIterator> >("HDTIterator", no_init)
-		.def("has_next", &HDTIterator::has_next)
-		.def("next", &HDTIterator::next)
+		.def("__iter__", pass_through) // inline function
+		.def("__next__", &HDTIterator::next)
 	  ;
   class_<HDTIteratorTripleID, shared_ptr<HDTIteratorTripleID> >("HDTIteratorTripleID", no_init)
-    .def("has_next", &HDTIteratorTripleID::has_next)
-    .def("next", &HDTIteratorTripleID::next)
+    .def("__iter__", pass_through) // inline function
+    .def("__next__", &HDTIteratorTripleID::next)
 	  ;
 
 	class_<HDTConnector, shared_ptr<HDTConnector> >("HDTConnector", no_init)

--- a/libhdtconnector/src/hdtconnector_so.cpp
+++ b/libhdtconnector/src/hdtconnector_so.cpp
@@ -16,29 +16,37 @@ static shared_ptr<HDTConnector> init_from_c_string(const string &val)
 
 BOOST_PYTHON_MODULE(libhdtconnector)
 {
+  enum_<TripleComponentRole>("triple_role")
+    .value("subject", SUBJECT)
+    .value("predicate", PREDICATE)
+    .value("object", OBJECT)
+    ; 
+
   class_<HDTTriple, shared_ptr<HDTTriple> >("HDTTriple", no_init)
     .def("get_subject", &HDTTriple::get_subject )
     .def("get_predicate", &HDTTriple::get_predicate )
     .def("get_object", &HDTTriple::get_object )
-  ;
+    ;
   class_<HDTTripleID, shared_ptr<HDTTripleID> >("HDTTripleID", no_init)
     .def("get_subject", &HDTTripleID::get_subject )
     .def("get_predicate", &HDTTripleID::get_predicate )
     .def("get_object", &HDTTripleID::get_object )
-  ;
+    ;
 
 	class_<HDTIterator, shared_ptr<HDTIterator> >("HDTIterator", no_init)
 		.def("has_next", &HDTIterator::has_next)
 		.def("next", &HDTIterator::next)
-	;
+	  ;
   class_<HDTIteratorTripleID, shared_ptr<HDTIteratorTripleID> >("HDTIteratorTripleID", no_init)
     .def("has_next", &HDTIteratorTripleID::has_next)
     .def("next", &HDTIteratorTripleID::next)
-	;
+	  ;
 
 	class_<HDTConnector, shared_ptr<HDTConnector> >("HDTConnector", no_init)
 		.def("__init__", make_constructor(&init_from_c_string))
 		.def("search", &HDTConnector::search)
     .def("search_id", &HDTConnector::search_id)
-	;
+    .def("id_to_uri", &HDTConnector::id_to_uri)
+    .def("uri_to_id", &HDTConnector::uri_to_id)
+	  ;
 }

--- a/libhdtconnector/src/include/HDTConnector.h
+++ b/libhdtconnector/src/include/HDTConnector.h
@@ -6,6 +6,7 @@
 #include <HDTManager.hpp>
 #include "ConvertProgress.h"
 #include "HDTIterator.h"
+#include "HDTIteratorTripleID.h"
 
 using namespace std;
 using namespace hdt;
@@ -19,6 +20,7 @@ public:
 	HDTConnector(const string &hdt_file);
 	virtual ~HDTConnector();
 	shared_ptr<HDTIterator> search(const wstring& uri1, const wstring& uri2, const wstring& uri3);
+  shared_ptr<HDTIteratorTripleID> search_id(const wstring& uri1, const wstring& uri2, const wstring& uri3);
 };
 
 #endif

--- a/libhdtconnector/src/include/HDTConnector.h
+++ b/libhdtconnector/src/include/HDTConnector.h
@@ -7,6 +7,7 @@
 #include "ConvertProgress.h"
 #include "HDTIterator.h"
 #include "HDTIteratorTripleID.h"
+#include "Utilities.h"
 
 using namespace std;
 using namespace hdt;
@@ -22,8 +23,8 @@ public:
 	shared_ptr<HDTIterator> search(const wstring& uri1, const wstring& uri2, const wstring& uri3);
   shared_ptr<HDTIteratorTripleID> search_id(const wstring& uri1, const wstring& uri2, const wstring& uri3);
   shared_ptr<HDTIteratorTripleID> search_id(unsigned int id1, unsigned int id2, unsigned int id3);
-  string id_to_uri(unsigned int id, TripleComponentRole role);
-  unsigned int uri_to_id(string uri, TripleComponentRole role);
+  wstring id_to_uri(unsigned int id, const TripleComponentRole& role);
+  unsigned int uri_to_id(const wstring& uri, const TripleComponentRole& role);
 };
 
 #endif

--- a/libhdtconnector/src/include/HDTConnector.h
+++ b/libhdtconnector/src/include/HDTConnector.h
@@ -21,6 +21,7 @@ public:
 	virtual ~HDTConnector();
 	shared_ptr<HDTIterator> search(const wstring& uri1, const wstring& uri2, const wstring& uri3);
   shared_ptr<HDTIteratorTripleID> search_id(const wstring& uri1, const wstring& uri2, const wstring& uri3);
+  shared_ptr<HDTIteratorTripleID> search_id(unsigned int id1, unsigned int id2, unsigned int id3);
   string id_to_uri(unsigned int id, TripleComponentRole role);
   unsigned int uri_to_id(string uri, TripleComponentRole role);
 };

--- a/libhdtconnector/src/include/HDTConnector.h
+++ b/libhdtconnector/src/include/HDTConnector.h
@@ -21,6 +21,8 @@ public:
 	virtual ~HDTConnector();
 	shared_ptr<HDTIterator> search(const wstring& uri1, const wstring& uri2, const wstring& uri3);
   shared_ptr<HDTIteratorTripleID> search_id(const wstring& uri1, const wstring& uri2, const wstring& uri3);
+  string id_to_uri(unsigned int id, TripleComponentRole role);
+  unsigned int uri_to_id(string uri, TripleComponentRole role);
 };
 
 #endif

--- a/libhdtconnector/src/include/HDTConnector.h
+++ b/libhdtconnector/src/include/HDTConnector.h
@@ -23,6 +23,7 @@ public:
 	shared_ptr<HDTIterator> search(const wstring& uri1, const wstring& uri2, const wstring& uri3);
   shared_ptr<HDTIteratorTripleID> search_id(const wstring& uri1, const wstring& uri2, const wstring& uri3);
   shared_ptr<HDTIteratorTripleID> search_id(unsigned int id1, unsigned int id2, unsigned int id3);
+  shared_ptr<HDTIteratorTripleID> search_id(TripleID& triple);
   wstring id_to_uri(unsigned int id, const TripleComponentRole& role);
   unsigned int uri_to_id(const wstring& uri, const TripleComponentRole& role);
 };

--- a/libhdtconnector/src/include/HDTIterator.h
+++ b/libhdtconnector/src/include/HDTIterator.h
@@ -19,7 +19,6 @@ public:
 	HDTIterator(IteratorTripleString *iter);
 	virtual ~HDTIterator();
 
-	bool has_next();
 	shared_ptr<HDTTriple> next();
 };
 

--- a/libhdtconnector/src/include/HDTIteratorTripleID.h
+++ b/libhdtconnector/src/include/HDTIteratorTripleID.h
@@ -2,10 +2,13 @@
 #define HDTITERATORTRIPLEID_H
 
 #include <HDTManager.hpp>
+#include <boost/python.hpp>
+#include <memory>
 #include "HDTTripleID.h"
 
 using namespace std;
 using namespace hdt;
+using namespace boost::python;
 
 class HDTIteratorTripleID
 {
@@ -16,7 +19,6 @@ public:
   HDTIteratorTripleID(IteratorTripleID *iter);
   virtual ~HDTIteratorTripleID();
 
-  bool has_next() const;
   shared_ptr<HDTTripleID> next();
 };
 

--- a/libhdtconnector/src/include/HDTIteratorTripleID.h
+++ b/libhdtconnector/src/include/HDTIteratorTripleID.h
@@ -1,0 +1,23 @@
+#ifndef HDTITERATORTRIPLEID_H
+#define HDTITERATORTRIPLEID_H
+
+#include <HDTManager.hpp>
+#include "HDTTripleID.h"
+
+using namespace std;
+using namespace hdt;
+
+class HDTIteratorTripleID
+{
+private:
+  IteratorTripleID *iter = NULL;
+
+public:
+  HDTIteratorTripleID(IteratorTripleID *iter);
+  virtual ~HDTIteratorTripleID();
+
+  bool has_next() const;
+  shared_ptr<HDTTripleID> next();
+};
+
+#endif

--- a/libhdtconnector/src/include/HDTTriple.h
+++ b/libhdtconnector/src/include/HDTTriple.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <boost/python.hpp>
 #include <HDTManager.hpp>
+#include "Utilities.h"
 
 using namespace std;
 using namespace hdt;
@@ -18,9 +19,9 @@ public:
   HDTTriple(TripleString *triple);
   virtual ~HDTTriple();
 
-  string get_subject() const;
-  string get_predicate() const;
-  string get_object() const;
+  wstring get_subject() const;
+  wstring get_predicate() const;
+  wstring get_object() const;
 };
 
 #endif

--- a/libhdtconnector/src/include/HDTTripleID.h
+++ b/libhdtconnector/src/include/HDTTripleID.h
@@ -1,0 +1,24 @@
+#ifndef HDTTRIPLEID_H
+#define HDTTRIPLEID_H
+
+#include <HDTManager.hpp>
+#include <memory>
+
+using namespace std;
+using namespace hdt;
+
+class HDTTripleID
+{
+private:
+  TripleID *triple = NULL;
+
+public:
+  HDTTripleID(TripleID *triple);
+  virtual ~HDTTripleID();
+
+  unsigned int get_subject() const;
+  unsigned int get_predicate() const;
+  unsigned int get_object() const;
+};
+
+#endif

--- a/libhdtconnector/src/include/Utilities.h
+++ b/libhdtconnector/src/include/Utilities.h
@@ -1,16 +1,29 @@
 #ifndef UTILITIES_H
 #define UTILITIES_H
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifdef HAVE_GLIB_2_2X
 #include <locale>
 #include <codecvt>
+#elif HAVE_BOOST_LOCALE
+#include <boost/locale/encoding_utf.hpp>
+#endif
 #include <string>
 
 using namespace std;
+#ifdef HAVE_BOOST_LOCALE
+using boost::locale::conv::utf_to_utf;
+#endif
 
 class Utilities
 {
 private:
+#ifdef HAVE_GLIB_2_2X
   static wstring_convert<codecvt_utf8_utf16<wchar_t>> converter;
+#endif
 
 public:
   static string unicode_to_utf8(const wstring& unicode); 

--- a/libhdtconnector/src/include/Utilities.h
+++ b/libhdtconnector/src/include/Utilities.h
@@ -5,10 +5,11 @@
 #include <config.h>
 #endif
 
-#ifdef HAVE_GLIB_2_2X
+#ifdef HAVE_CODECVT
 #include <locale>
 #include <codecvt>
-#elif HAVE_BOOST_LOCALE
+#endif
+#ifdef HAVE_BOOST_LOCALE
 #include <boost/locale/encoding_utf.hpp>
 #endif
 #include <string>
@@ -21,7 +22,7 @@ using boost::locale::conv::utf_to_utf;
 class Utilities
 {
 private:
-#ifdef HAVE_GLIB_2_2X
+#ifdef HAVE_CODECVT
   static wstring_convert<codecvt_utf8_utf16<wchar_t>> converter;
 #endif
 

--- a/libhdtconnector/src/include/Utilities.h
+++ b/libhdtconnector/src/include/Utilities.h
@@ -1,0 +1,20 @@
+#ifndef UTILITIES_H
+#define UTILITIES_H
+
+#include <locale>
+#include <codecvt>
+#include <string>
+
+using namespace std;
+
+class Utilities
+{
+private:
+  static wstring_convert<codecvt_utf8_utf16<wchar_t>> converter;
+
+public:
+  static string unicode_to_utf8(const wstring& unicode); 
+  static wstring utf8_to_unicode(const string& utf8);
+};
+
+#endif


### PR DESCRIPTION
Provide a mechanism to query the HDT file with the indices  instead of uri. This can help to reduce the overhead of keeping uris (strings) in memory when analysing large hdt files.